### PR TITLE
feat: enabling sold out label on third ticket batch

### DIFF
--- a/src/components/tickets.astro
+++ b/src/components/tickets.astro
@@ -32,7 +32,7 @@ const tickets = [
     valueMin: '189',
     valueMax: '378',
     isEnable: true,
-    soldOut: false,
+    soldOut: true,
   }
 ];
 ---


### PR DESCRIPTION
Adding the soldOut boolean value for the third batch of tickets

**Before**
![image](https://github.com/frontinsampa/site2023/assets/52542050/6d8fafe0-991e-4795-a213-c198ed75a232)
![image](https://github.com/frontinsampa/site2023/assets/52542050/1baffd44-afc2-4707-a1a2-0a67c37587d5)


**After**
![image](https://github.com/frontinsampa/site2023/assets/52542050/014c9aef-3e6a-40c8-815f-179a498a8bfb)
![image](https://github.com/frontinsampa/site2023/assets/52542050/07e710a7-0e49-4978-9553-1d9386eac82e)

